### PR TITLE
Fixes pre-commit hook to read staging area

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,7 +4,14 @@
 echo INFO: Pre-commit hook running from $PWD
 git version
 
+# Stash any changes to the working tree that are not going to be committed
+git stash -q --keep-index
+
 #check that the EDAM source file is in the right format (RDF/XML)
 grep -c 'owl:Class' EDAM_dev.owl
 owlclassfound=$?
+
+# Unstash changes to the working tree that we had stashed
+git stash pop -q
+
 exit $owlclassfound


### PR DESCRIPTION
#622 

Fixed the Pre-commit hook script by stashing all changes that are not part of the staging area before running our checks and then popping them back.

Co-authored by: @matuskalas 