### PR TITLE
Fixing issue 644: Add post-commit hook

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Simple text to inform user about commit
+echo INFO: Yay! Your commit to EDAM Ontology was successful.
+
+exit 0


### PR DESCRIPTION
# This PR fixes issue #644 and the issue in PR #652

# Summary
I have added a simple bash script for `post-commit` in `.githooks` which displays a message after making a  commit for the EDAM Ontology organization. 

Co-author: @matuskalas 


@matuskalas I have successfully made the necessary changes. Kindly review my script and let me know if any improvements are needed. Thank you. 