### PR TITLE
added: commit message template

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,27 @@
+########  Summarise the Topic line of commit in 50 characters or less ######## 
+# Write an imperative tense: “Fix bug”. [Add |Fix | Remove| Update| Refactor]
+Subject/Topic (of the commit to be made)
+
+######## Bullet point reasons for the commit ########  
+Because: 
+- Explain the reason why you made these fixes/changes
+- Make a bullet point for all the the reasons
+- Each line should be under 72 characters
+and so on...
+
+####### Description of the solution ########
+Explain exactly what was done in this commit with more depth than the
+50 character subject line. Remember to wrap at 72 characters!
+
+####### Reference the link to issue you were working on #######
+Link to the issue
+
+####### Update the status #######
+- [] Make a Pull Request
+- [] Work in progress
+
+####### Add a line to warn if you removed any dependency or any special instructions you want to include [in 72 characters] ######
+Warning/Note 
+
+####### Include your GitHub username on the commit including @matuskalas #######
+Co-authored by: 


### PR DESCRIPTION
# This PR fixes issue #614 

# Summary 
I have made a basic commit message template

## Description of the template added
Added the template in the form of a file `.gitmessage`. The template consists of the following parameters which a contributor needs to mention before a commit.
- Topic line
- Reason for the commit
- Description of the solution suggested
- Reference to the issue
- Status of the commit
- Warning/Note
- Co-author's mention


@matuskalas kindly review my (new clean) PR and let me know if any improvements are needed. Thank you.