### PR TITLE
Updates PTM site prediction operation

### DIFF
--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -41176,7 +41176,7 @@ sequences matching a given sequence motif or pattern, such as a Prosite pattern 
         <oboInOwl:hasExactSynonym>PTM site analysis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Post-translation modification site prediction</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Post-translational modification analysis</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>Post-translational modification site prediction</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>PTM site prediction</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Protein post-translation modification site prediction</oboInOwl:hasExactSynonym>
         <oboInOwl:hasNarrowSynonym>Acetylation prediction</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>Acetylation site prediction</oboInOwl:hasNarrowSynonym>
@@ -41226,7 +41226,7 @@ sequences matching a given sequence motif or pattern, such as a Prosite pattern 
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#operations"/>
         <rdfs:comment>Methods might predict sites of methylation, N-terminal myristoylation, N-terminal acetylation, sumoylation, palmitoylation, phosphorylation, sulfation, glycosylation, glycosylphosphatidylinositol (GPI) modification sites (GPI lipid anchor signals) etc.</rdfs:comment>
-        <rdfs:label>PTM site prediction</rdfs:label>
+        <rdfs:label>Post-translational modification site prediction</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
Switched the old label of operation "Post-translation modification site prediction" and one of its exact synonyms ("PTM site prediction").
The idea is to have the label spelled out, and acronyms as exact synonyms.