### PR TITLE
Extend JCAMP-DX which also captures other measurement techniques.

### DIFF
--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -35919,14 +35919,16 @@ experiments employing a combination of technologies.</oboInOwl:hasDefinition>
     <owl:Class rdf:about="http://edamontology.org/format_3859">
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_3245"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_3824"/>
         <created_in>1.21</created_in>
         <documentation rdf:resource="http://www.jcamp-dx.org/drafts/JCAMP6_2b%20Draft.pdf"/>
-        <oboInOwl:hasDefinition>A standardized file format for data exchange in mass spectrometry, initially developed for infrared spectrometry.</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>A standardized file format for data exchange in analytical chemistry for e.g. mass spectrometry, NMR or infrared spectrometry.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:comment>JCAMP-DX is an ASCII based format and therefore not very compact even though it includes standards for file compression.</rdfs:comment>
         <rdfs:label>JCAMP-DX</rdfs:label>
         <rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Mass_spectrometry_data_format#cite_note-3"/>
+	<rdfs:seeAlso rdf:resource="https://de.wikipedia.org/wiki/JCAMP-DX#cite_note-5"/>
     </owl:Class>
     
 


### PR DESCRIPTION
Hi, with @cb2993 we are currently going through data formats in chemistry. 
JCAMP-DX can also be thought of as a container format, which has a header section and numerical data. This can capture both MS, NMR and in analytical chemistry several other measurement types. 
After reading https://edamontologydocs.readthedocs.io/en/latest/editors_guide.html#id12 I am unsure whether to 1) extend JCAMP-DX to NMR (that is what thus PR does), or to 2) add a new generic JCAMP-DX, and have the format_3859 be a child, and create a new child specifically for the JCAMP-DX NMR flavour.
Some JCAMP-DX readers/viewers can cope with multiple JCAMP types, that would favour option 1). 
I have a converter tool in CWL that outputs specifically a JCAMP-DX NMR file, which could be labelled with a new 2) JCAMP-DX NMR format. 
bio.tools has https://bio.tools/t?page=1&q=JCAMP one tool specifically for MS Data, and one for both MS and NMR. Interestingly, none of them specify JCAMP as input format :-(
Suggestions welcome. Yours, Steffen