### PR TITLE
Remove synonym Metatranscriptomics from topic Transcriptomics

### DIFF
--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -57397,7 +57397,6 @@ ows re-sequencing of complete genomes of any given organism with high resolution
         <oboInOwl:hasDefinition>The analysis of transcriptomes, or a set of all the RNA molecules in a specific cell, tissue etc.</oboInOwl:hasDefinition>
         <oboInOwl:hasHumanReadableId>Transcriptomics</oboInOwl:hasHumanReadableId>
         <oboInOwl:hasNarrowSynonym>Comparative transcriptomics</oboInOwl:hasNarrowSynonym>
-        <oboInOwl:hasNarrowSynonym>Metatranscriptomics</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym>Transcriptome</oboInOwl:hasNarrowSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#events"/>


### PR DESCRIPTION
Removes synonym Metatranscriptomics from Transcriptomics. Metatranscriptomics is also a topic. Fixes #741.