### PR TITLE
feat: added formats for logical modeling

### DIFF
--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -13,8 +13,8 @@
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
      xmlns:oboOther="http://purl.obolibrary.org/obo/">
     <owl:Ontology rdf:about="http://edamontology.org">
-        <next_id>4020</next_id>
-        <oboOther:date>06.09.2021 08:04 UTC</oboOther:date>
+        <next_id>4032</next_id>
+        <oboOther:date>21.09.2021 14:49 UTC</oboOther:date>
         <oboOther:idspace>EDAM http://edamontology.org/ &quot;EDAM relations and concept properties&quot;</oboOther:idspace>
         <oboOther:idspace>EDAM_data http://edamontology.org/data_ &quot;EDAM types of data&quot;</oboOther:idspace>
         <oboOther:idspace>EDAM_format http://edamontology.org/format_ &quot;EDAM data formats&quot;</oboOther:idspace>
@@ -60596,6 +60596,395 @@ ows re-sequencing of complete genomes of any given organism with high resolution
         <rdfs:subClassOf rdf:resource="http://edamontology.org/topic_0003"/>
         <rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/List_of_life_sciences"/>
     </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4020 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4020">
+        <created_in>1.26</created_in>
+        <rdfs:label>BoolNet</rdfs:label>
+        <file_extension>bnet</file_extension>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-boolnet"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>Format for Boolean regulatory networks used by BoolNet, pyBoolNet, bioLQM, and other logical modeling tools.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://cran.r-project.org/web/packages/BoolNet/index.html"/>
+        <documentation rdf:resource="https://sysbio.uni-ulm.de/?Software:BoolNet"/>
+        <citation rdf:resource="https://doi.org/10.1093/bioinformatics/btq124"/>
+        <example rdf:resource="https://cran.r-project.org/web/packages/BoolNet/BoolNet.pdf"/>
+        <example rdf:resource="https://github.com/hklarner/pyboolnet/tree/master/tests/files_input"/>        
+        <organisation rdf:resource="https://sysbio.uni-ulm.de/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4021 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4021">
+        <created_in>1.26</created_in>
+        <rdfs:label>boolSim</rdfs:label>
+        <file_extension>net</file_extension>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-boolsim"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>Format for Boolean regulatory networks used by boolSim, GenYsis, SQUAD, bioLQM, and other logical modeling tools.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://www.vital-it.ch/research/software/boolSim"/>
+        <citation rdf:resource="https://doi.org/10.1093/bioinformatics/btn336"/>
+        <example rdf:resource="https://www.vital-it.ch/research/software/boolSim"/>
+        <organisation rdf:resource="https://www.vital-it.ch/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4022 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4022">
+        <created_in>1.26</created_in>
+        <rdfs:label>BooleanNet</rdfs:label>
+        <file_extension>txt</file_extension>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-booleannet"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>Format for Boolean regulatory networks used by BooleanNet, bioLQM, and other logical modeling tools.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://github.com/ialbert/booleannet"/>
+        <citation rdf:resource="https://doi.org/10.1186/1751-0473-3-16"/>
+        <example rdf:resource="https://github.com/ialbert/booleannet/tree/master/examples"/>
+        <organisation rdf:resource="https://www.ialbert.me/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4023 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4023">
+        <created_in>1.26</created_in>
+        <rdfs:label>CNET</rdfs:label>
+        <file_extension>cnet</file_extension>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-cnet"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>Format for Boolean regulatory networks used by Boolean Networks with Synchronous update (BNS), bioLQM, and other logical modeling tools.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://people.kth.se/~dubrova/bns.html"/>
+        <citation rdf:resource="https://doi.org/10.1109/TCBB.2010.20"/>
+        <example rdf:resource="https://people.kth.se/~dubrova/bns.html"/>
+        <organisation rdf:resource="https://people.kth.se/~dubrova/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4024 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4024">
+        <created_in>1.26</created_in>
+        <rdfs:label>GNA</rdfs:label>
+        <file_extension>gna</file_extension>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-gna"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>Format for Boolean regulatory networks used by Genetic Network Analyzer (GNA), bioLQM, and other logical modeling tools.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="http://ibis.inrialpes.fr/people/dejong/GNA/user/ch03.html"/>
+        <citation rdf:resource="https://doi.org/10.1093/bioinformatics/btf851"/>
+        <citation rdf:resource="https://doi.org/10.1007/978-1-61779-361-5_22"/>
+        <example rdf:resource="http://colomoto.org/biolqm/doc/format-gna.html"/>
+        <organisation rdf:resource="https://team.inria.fr/ibis/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4025 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4025">
+        <created_in>1.26</created_in>
+        <rdfs:label>MaBoSS</rdfs:label>
+        <file_extension>bnd</file_extension>
+        <file_extension>cfg</file_extension>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-bnd"/>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-cfg"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>Format for continuous/discrete time Markov processes applied on Boolean networks used by MaBoSS, bioLQM, and other logical modeling tools.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_3241"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://maboss.curie.fr/"/>
+        <citation rdf:resource="https://doi.org/10.1186/1752-0509-6-116"/>
+        <citation rdf:resource="https://doi.org/10.1093/bioinformatics/btx123"/>
+        <example rdf:resource="https://maboss.curie.fr/"/>
+        <organisation rdf:resource="https://maboss.curie.fr/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4026 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4026">
+        <created_in>1.26</created_in>
+        <rdfs:label>Pint</rdfs:label>
+        <file_extension>an</file_extension>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-an"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>Format for Boolean networks used by Pint, bioLQM, and other logical modeling tools.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://loicpauleve.name/pint/"/>
+        <citation rdf:resource="https://doi.org/10.1007/978-3-319-67471-1_20"/>
+        <example rdf:resource="https://github.com/pauleve/pint/tree/master/tests/models"/>
+        <organisation rdf:resource="https://loicpauleve.name/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4027 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4027">
+        <created_in>1.26</created_in>
+        <rdfs:label>TruthTable</rdfs:label>
+        <file_extension>txt</file_extension>  
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-truthtable"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>Format for Boolean networks used by bioLQM and other logical modeling tools.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="http://colomoto.org/formats/truthtable.html"/>
+        <example rdf:resource="http://colomoto.org/formats/truthtable.html"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4028 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4028">
+        <created_in>1.26</created_in>
+        <rdfs:label>NuSMV</rdfs:label>
+        <file_extension>smv</file_extension>  
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-smv"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>Format for Boolean networks used by NuSMV and other logical modeling tools.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://nusmv.fbk.eu/NuSMV/userman/index-v2.html"/>
+        <citation rdf:resource="https://doi.org/10.1007/3-540-48683-6_44"/>
+        <citation rdf:resource="https://doi.org/10.1007/3-540-45657-0_29"/>
+        <citation rdf:resource="https://doi.org/10.1007/s100090050046"/>
+        <example rdf:resource="https://nusmv.fbk.eu/examples/examples.html"/>
+        <organisation rdf:resource="https://nusmv.fbk.eu/NuSMV/project_members.html"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4029 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4029">
+        <created_in>1.26</created_in>
+        <rdfs:label>PNML</rdfs:label>
+        <file_extension>pnml</file_extension>  
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/application/pnml+xml"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>The Petri Net Markup Language (PNML) is a format for petri nets.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2332"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://www.pnml.org/"/>
+        <citation rdf:resource="https://doi.org/10.1007/978-3-642-35179-2_3"/>
+        <citation rdf:resource="https://doi.org/10.1007/978-3-642-13675-7_20"/>
+        <citation rdf:resource="https://doi.org/10.1007/3-540-44919-1_31"/>
+        <citation rdf:resource="https://doi.org/10.1007/978-3-540-40022-6_7"/>
+        <organisation rdf:resource="https://www.pnml.org/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4030 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4030">
+        <created_in>1.26</created_in>
+        <rdfs:label>APNN</rdfs:label>
+        <file_extension>apnn</file_extension>  
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/application/x-apnn"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>The Abstract Petri net notation (APNN) is a format for petri nets.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2332"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://ls4-www.cs.tu-dortmund.de/APNN-TOOLBOX/"/>
+        <citation rdf:resource="https://doi.org/10.1007/3-540-48683-6_41"/>
+        <example rdf:resource="https://ls4-www.cs.tu-dortmund.de/APNN-TOOLBOX/"/>
+        <organisation rdf:resource="https://ls4-www.cs.tu-dortmund.de/cms/de/ls4/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4031 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4031">
+        <created_in>1.26</created_in>
+        <rdfs:label>INA</rdfs:label>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>The Integrated Net Analyzer (INA) is a format for petri nets.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2332"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="https://www2.informatik.hu-berlin.de/~starke/ina.html"/>
+        <organisation rdf:resource="https://www2.informatik.hu-berlin.de/~starke/"/>
+    </owl:Class>
+
 
 
 

--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -35661,7 +35661,7 @@ experiments employing a combination of technologies.</oboInOwl:hasDefinition>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_3547"/>
         <created_in>1.20</created_in>
         <documentation rdf:resource="https://msdn.microsoft.com/en-us/library/dd926741(v=office.12).aspx"/>
-        <media_type rdf:resource="https://www.iana.org/assignments/media-types/application/vnd.openxmlformats-officedocument.presentationml.presentation"/>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/application/vnd.openxmlformats-officedocument.presentationml.presentation"/>
         <oboInOwl:hasDefinition>Microsoft Powerpoint format.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
@@ -36536,7 +36536,7 @@ experiments employing a combination of technologies.</oboInOwl:hasDefinition>
         <documentation rdf:resource="https://bcforms.org"/>
         <documentation rdf:resource="https://raw.githubusercontent.com/KarrLab/bcforms/master/bcforms/grammar.lark"/>
         <example rdf:resource="https://bcforms.org"/>
-        <media_type>text/plain</media_type>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/plain"/>
         <ontology_used rdf:resource="https://www.bpforms.org/crosslink"/>
         <organisation rdf:resource="https://www.karrlab.org"/>
         <oboInOwl:hasDefinition>BcForms is a format for abstractly describing the molecular structure (atoms and bonds) of macromolecular complexes as a collection of subunits and crosslinks. Each subunit can be described with BpForms (http://edamontology.org/format_3909) or SMILES (http://edamontology.org/data_2301). BcForms uses an ontology of crosslinks to abstract the chemical details of crosslinks from the descriptions of complexes (see https://bpforms.org/crosslink.html).</oboInOwl:hasDefinition>
@@ -36574,7 +36574,7 @@ experiments employing a combination of technologies.</oboInOwl:hasDefinition>
         <documentation rdf:resource="https:doi.org/10.1145/2642918.2647360"/>
         <example rdf:resource="https://vega.github.io/vega/examples/"/>
         <file_extension>json</file_extension>
-        <media_type>application/json</media_type>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/application/json"/>
         <organisation rdf:resource="http://idl.cs.washington.edu/"/>
         <oboInOwl:hasDefinition>Vega is a visualization grammar, a declarative language for creating, saving, and sharing interactive visualization designs. With Vega, you can describe the visual appearance and interactive behavior of a visualization in a JSON format, and generate web-based views using Canvas or SVG.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
@@ -36595,7 +36595,7 @@ experiments employing a combination of technologies.</oboInOwl:hasDefinition>
         <documentation rdf:resource="https://vega.github.io/vega-lite/docs/#spec"/>
         <example rdf:resource="https://vega.github.io/vega-lite/examples/"/>
         <file_extension>json</file_extension>
-        <media_type>application/json</media_type>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/application/json"/>
         <organisation rdf:resource="http://idl.cs.washington.edu/"/>
         <oboInOwl:hasDefinition>Vega-Lite is a high-level grammar of interactive graphics. It provides a concise JSON syntax for rapidly generating visualizations to support analysis. Vega-Lite specifications can be compiled to Vega specifications.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
@@ -36621,7 +36621,7 @@ experiments employing a combination of technologies.</oboInOwl:hasDefinition>
         <documentation rdf:resource="https://neuroml.org/"/>
         <example rdf:resource="https://neuroml-db.org/"/>
         <example rdf:resource="https://neuroml.org/neuromlv2"/>
-        <media_type>application/xml</media_type>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/application/xml"/>
         <organisation rdf:resource="https://neuroml.org/editors"/>
         <oboInOwl:hasDefinition>A model description language for computational neuroscience.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
@@ -36648,8 +36648,8 @@ experiments employing a combination of technologies.</oboInOwl:hasDefinition>
         <documentation rdf:resource="https://doi.org/10.1007/978-1-61779-833-7_9"/>
         <example rdf:resource="https://github.com/RuleWorld/BNGTutorial/blob/master/README.md"/>
         <file_extension>bngl</file_extension>
-        <media_type>application/xml</media_type>
-        <media_type>plain/text</media_type>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/application/xml"/>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/plain/text"/>
         <organisation rdf:resource="https://www.csb.pitt.edu/Faculty/Faeder/"/>
         <oboInOwl:hasDefinition>BioNetGen is a format for the specification and simulation of rule-based models of biochemical systems, including signal transduction, metabolic, and genetic regulatory networks.</oboInOwl:hasDefinition>
         <oboInOwl:hasExactSynonym>BioNetGen Language</oboInOwl:hasExactSynonym>
@@ -36727,7 +36727,7 @@ experiments employing a combination of technologies.</oboInOwl:hasDefinition>
         <documentation rdf:resource="https://www.objtables.org/docs"/>
         <example rdf:resource="https://www.objtables.org/docs#examples"/>
         <file_extension>xlsx</file_extension>
-        <media_type>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</media_type>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>
         <organisation rdf:resource="https://www.karrlab.org"/>
         <oboInOwl:hasDefinition>ObjTables is a toolkit for creating re-usable datasets that are both human and machine-readable, combining the ease of spreadsheets (e.g., Excel workbooks) with the rigor of schemas (classes, their attributes, the type of each attribute, and the possible relationships between instances of classes). ObjTables consists of a format for describing schemas for spreadsheets, numerous data types for science, a syntax for indicating the class and attribute represented by each table and column in a workbook, and software for using schemas to rigorously validate, merge, split, compare, and revision datasets.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>

--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -60996,7 +60996,7 @@ ows re-sequencing of complete genomes of any given organism with high resolution
         <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-blif"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
-        <oboInOwl:hasDefinition>The Berkeley Logic Interchange Format (APNN) is a format for Boolean networks.</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>The Berkeley Logic Interchange Format (BLIF) is a format for Boolean networks.</oboInOwl:hasDefinition>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
         <rdfs:subClassOf>

--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -13,7 +13,7 @@
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
      xmlns:oboOther="http://purl.obolibrary.org/obo/">
     <owl:Ontology rdf:about="http://edamontology.org">
-        <next_id>4032</next_id>
+        <next_id>4033</next_id>
         <oboOther:date>21.09.2021 14:49 UTC</oboOther:date>
         <oboOther:idspace>EDAM http://edamontology.org/ &quot;EDAM relations and concept properties&quot;</oboOther:idspace>
         <oboOther:idspace>EDAM_data http://edamontology.org/data_ &quot;EDAM types of data&quot;</oboOther:idspace>
@@ -60933,11 +60933,11 @@ ows re-sequencing of complete genomes of any given organism with high resolution
         <created_in>1.26</created_in>
         <rdfs:label>APNN</rdfs:label>
         <file_extension>apnn</file_extension>  
-        <media_type rdf:resource="http://www.iana.org/assignments/media-types/application/x-apnn"/>
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-apnn"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <oboInOwl:hasDefinition>The Abstract Petri net notation (APNN) is a format for petri nets.</oboInOwl:hasDefinition>
-        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2332"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -60967,7 +60967,7 @@ ows re-sequencing of complete genomes of any given organism with high resolution
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <oboInOwl:hasDefinition>The Integrated Net Analyzer (INA) is a format for petri nets.</oboInOwl:hasDefinition>
-        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2332"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
         <rdfs:subClassOf>
             <owl:Restriction>
@@ -60983,6 +60983,35 @@ ows re-sequencing of complete genomes of any given organism with high resolution
         </rdfs:subClassOf>
         <documentation rdf:resource="https://www2.informatik.hu-berlin.de/~starke/ina.html"/>
         <organisation rdf:resource="https://www2.informatik.hu-berlin.de/~starke/"/>
+    </owl:Class>
+
+
+
+    <!-- http://edamontology.org/format_4032 -->
+
+    <owl:Class rdf:about="http://edamontology.org/format_4032">
+        <created_in>1.26</created_in>
+        <rdfs:label>BLIF</rdfs:label>
+        <file_extension>blif</file_extension>  
+        <media_type rdf:resource="http://www.iana.org/assignments/media-types/text/x-blif"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
+        <oboInOwl:hasDefinition>The Berkeley Logic Interchange Format (APNN) is a format for Boolean networks.</oboInOwl:hasDefinition>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2013"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_0950"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://edamontology.org/is_format_of"/>
+                <owl:someValuesFrom rdf:resource="http://edamontology.org/data_2600"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <documentation rdf:resource="http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.115.9222"/>
     </owl:Class>
 
 


### PR DESCRIPTION
Added several formats used by the [CoLoMoTo Consortium](http://colomoto.org/) for logical and petri net modelling.

- Petri nets
  - Abstract Petri net notation (APNN)
  - Integrated Net Analyzer (INA)
  - Petri Net Markup Language (PNML)
- Boolean/logical networks
  - Berkeley Logic Interchange Format (BLIF)
  - BooleanNet
  - BoolNet
  - boolSim
  - CNET
  - Genetic Network Analzyer (GNA)
  - Pint
  - TruthTable
- Continuous/discrete time Markov processes applied on Boolean networks
  - MaBoSS
