### PR TITLE
Fixing typo error from merge PR#680

### DIFF
--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -60602,19 +60602,19 @@ ows re-sequencing of complete genomes of any given organism with high resolution
     <!-- http://edamontology.org/topic_4020 -->
 
     <owl:Class rdf:about="http://edamontology.org/topic_4020">
-	<rdfs:subClassOf rdf:resource="http://edamontology.org/topic_3855"/>
-	<rdfs:subClassOf rdf:resource="http://edamontology.org/topic_0610"/>
-	<rdfs:subClassOf rdf:resource="http://edamontology.org/topic_3314"/>
-	<rdfs:subClassOf rdf:resource="http://edamontology.org/topic_3318"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/topic_3855"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/topic_0610"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/topic_3314"/>
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/topic_3318"/>
         <created_in>1.26</created_in>
         <oboInOwl:hasDefinition>The carbon cycle is the biogeochemical pathway of carbon moving through the different parts of the Earth (such as ocean, atmosphere, soil), or eventually another planet.</oboInOwl:hasDefinition>
         <oboInOwl:hasBroadSynonym>Biogeochemical cycle</oboInOwl:hasBroadSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#topics"/>
         <rdfs:label>Carbon cycle</rdfs:label>
-	<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Carbon_cycle"/>
-	<rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Biogeochemical_cycle"/>
-	<rdfs:comment>Note that the carbon-nitrogen-oxygen (CNO) cycle (https://en.wikipedia.org/wiki/CNO_cycle) is a completely different, thermonuclear reaction in stars.</rdfs:comment>
+        <rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Carbon_cycle"/>
+        <rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Biogeochemical_cycle"/>
+        <rdfs:comment>Note that the carbon-nitrogen-oxygen (CNO) cycle (https://en.wikipedia.org/wiki/CNO_cycle) is a completely different, thermonuclear reaction in stars.</rdfs:comment>
     </owl:Class>
 
 


### PR DESCRIPTION
When adding the carbon cycle concept some tab replaced spaces for indent. 