### PR TITLE
Validation with ROBOT

### DIFF
--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -1,0 +1,29 @@
+name: ROBOT
+
+on:
+  push:
+    branches: [ validation ]
+  pull_request:
+    branches: [ validation ]
+jobs:
+  
+  build:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+      
+     - uses: actions/checkout@v2
+
+     - name: Set up 
+        run: |
+          git clone https://github.com/edamontology/edamverify.git
+
+          wget https://github.com/ontodev/robot/releases/download/v1.8.1/robot.jar -P /usr/local/bin
+          curl https://raw.githubusercontent.com/ontodev/robot/master/bin/robot > /usr/local/bin/robot
+
+     - name: run reason
+          robot reason --reasoner ELK   --input EDAM_dev.owl  
+
+     - name: run report 
+          robot report --input EDAM_dev.owl --output edamverify/robot/report_profile.tsv --profile edamverify/robot/report_queries.txt

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -1,7 +1,7 @@
 name: ROBOT
 
 on:
-  [workflow_dispatch]
+   [push, pull_request, workflow_dispatch]
 
 jobs:
   

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -27,7 +27,11 @@ jobs:
         cd edamverify/robot/
         export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile report_queries.txt
-        more report_profile.tsv
+
+    - name: Print report output
+      run: |
+        more edamverify/report_profile.tsv
+
 
     - name: Archive Robot report tests
       if: always()

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -18,8 +18,7 @@ jobs:
     - name: Set up 
       run: |
         git clone https://github.com/edamontology/edamverify.git
-        pwd
-        PATH=./edamverify/robot:$PATH
+        PATH=/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         export PATH
 
 

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -16,7 +16,7 @@ jobs:
      - uses: actions/checkout@v2
 
      - name: Set up 
-        run: |
+       run: |
           git clone https://github.com/edamontology/edamverify.git
 
           wget https://github.com/ontodev/robot/releases/download/v1.8.1/robot.jar -P /usr/local/bin

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -18,14 +18,13 @@ jobs:
     - name: Set up 
       run: |
         git clone https://github.com/edamontology/edamverify.git
-        PATH=/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
-        export PATH
-
 
     - name: run reason
       run: |
+        export PATH=/home/lamothe/work/robot:$PATH
         robot reason --reasoner ELK   --input EDAM_dev.owl  
 
     - name: run report 
       run: |
+        export PATH=/home/lamothe/work/robot:$PATH
         robot report --input EDAM_dev.owl --output edamverify/robot/report_profile.tsv --profile edamverify/robot/report_queries.txt

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -8,22 +8,22 @@ on:
 jobs:
   
   build:
-    
+
     runs-on: ubuntu-latest
 
     steps:
       
-     - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-     - name: Set up 
-       run: |
-          git clone https://github.com/edamontology/edamverify.git
+    - name: Set up 
+      run: |
+        git clone https://github.com/edamontology/edamverify.git
 
-          wget https://github.com/ontodev/robot/releases/download/v1.8.1/robot.jar -P /usr/local/bin
-          curl https://raw.githubusercontent.com/ontodev/robot/master/bin/robot > /usr/local/bin/robot
+        wget https://github.com/ontodev/robot/releases/download/v1.8.1/robot.jar -P /usr/local/bin
+        curl https://raw.githubusercontent.com/ontodev/robot/master/bin/robot > /usr/local/bin/robot
 
-     - name: run reason
-          robot reason --reasoner ELK   --input EDAM_dev.owl  
+    - name: run reason
+        robot reason --reasoner ELK   --input EDAM_dev.owl  
 
-     - name: run report 
-          robot report --input EDAM_dev.owl --output edamverify/robot/report_profile.tsv --profile edamverify/robot/report_queries.txt
+    - name: run report 
+        robot report --input EDAM_dev.owl --output edamverify/robot/report_profile.tsv --profile edamverify/robot/report_queries.txt

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -23,7 +23,9 @@ jobs:
         curl https://raw.githubusercontent.com/ontodev/robot/master/bin/robot > /usr/local/bin/robot
 
     - name: run reason
+      run: |
         robot reason --reasoner ELK   --input EDAM_dev.owl  
 
     - name: run report 
+      run: |
         robot report --input EDAM_dev.owl --output edamverify/robot/report_profile.tsv --profile edamverify/robot/report_queries.txt

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -23,10 +23,12 @@ jobs:
         robot reason --reasoner ELK   --input EDAM_dev.owl -v 
 
     - name: run report 
-      run: |
+      if: always()
+       run: |
         cd edamverify/robot/
         export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile report_queries.txt
+        more edamverify/robot/report_profile.tsv
 
     - name: Print report output
       if: always()

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -1,6 +1,7 @@
 name: ROBOT
 
 on:
+  workflow_dispatch:
   push:
     branches: [ validation ]
   pull_request:

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -28,4 +28,4 @@ jobs:
       run: |
         cd edamverify/robot/
         export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
-        robot report --input EDAM_dev.owl --output edamverify/robot/report_profile.tsv --profile edamverify/robot/report_queries.txt
+        robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile edamverify/robot/report_queries.txt

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -18,9 +18,10 @@ jobs:
     - name: Set up 
       run: |
         git clone https://github.com/edamontology/edamverify.git
+        ls
+        PATH=./edamverify/robot:$PATH
+        export PATH
 
-        wget https://github.com/ontodev/robot/releases/download/v1.8.1/robot.jar -P /usr/local/bin
-        curl https://raw.githubusercontent.com/ontodev/robot/master/bin/robot > /usr/local/bin/robot
 
     - name: run reason
       run: |

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -35,4 +35,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: robot_report_profile
-        path: report_profile.tsv
+        path: edamverify/robot/report_profile.tsv

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -18,11 +18,12 @@ jobs:
     - name: Set up 
       run: |
         git clone https://github.com/edamontology/edamverify.git
+        cd edamverify/robot/
 
     - name: run reason
       run: |
         export PATH=/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
-        robot reason --reasoner ELK   --input EDAM_dev.owl  
+        robot reason --reasoner ELK   --input EDAM_dev.owl -v 
 
     - name: run report 
       run: |

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -21,10 +21,10 @@ jobs:
 
     - name: run reason
       run: |
-        export PATH=/home/lamothe/work/robot:$PATH
+        export PATH=/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         robot reason --reasoner ELK   --input EDAM_dev.owl  
 
     - name: run report 
       run: |
-        export PATH=/home/lamothe/work/robot:$PATH
+        export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         robot report --input EDAM_dev.owl --output edamverify/robot/report_profile.tsv --profile edamverify/robot/report_queries.txt

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -31,7 +31,8 @@ jobs:
         export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile report_queries.txt
 
-    - name: Artifact
+    - name: Archive Robot report tests
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: robot_report_profile

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -29,3 +29,9 @@ jobs:
         cd edamverify/robot/
         export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile report_queries.txt
+
+    - name: Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: robot_report_profile
+        path: report_profile.tsv

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -18,7 +18,6 @@ jobs:
     - name: Set up 
       run: |
         git clone https://github.com/edamontology/edamverify.git
-        cd edamverify/robot/
 
     - name: run reason
       run: |
@@ -27,5 +26,6 @@ jobs:
 
     - name: run report 
       run: |
+        cd edamverify/robot/
         export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         robot report --input EDAM_dev.owl --output edamverify/robot/report_profile.tsv --profile edamverify/robot/report_queries.txt

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -29,6 +29,7 @@ jobs:
         robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile report_queries.txt
 
     - name: Print report output
+      if: always()
       run: |
         more edamverify/report_profile.tsv
 

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up 
       run: |
         git clone https://github.com/edamontology/edamverify.git
-        ls
+        pwd
         PATH=./edamverify/robot:$PATH
         export PATH
 

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -1,11 +1,8 @@
 name: ROBOT
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [ validation ]
-  pull_request:
-    branches: [ validation ]
+  [push, pull_request, workflow_dispatch]
+
 jobs:
   
   build:

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: run report 
       if: always()
-       run: |
+      run: |
         cd edamverify/robot/
         export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile report_queries.txt

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -1,7 +1,7 @@
 name: ROBOT
 
 on:
-  [push, pull_request, workflow_dispatch]
+  [workflow_dispatch]
 
 jobs:
   

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -1,7 +1,7 @@
 name: ROBOT
 
 on:
-   [push, pull_request, workflow_dispatch]
+  [push, pull_request, workflow_dispatch]
 
 jobs:
   
@@ -27,6 +27,7 @@ jobs:
         cd edamverify/robot/
         export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
         robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile report_queries.txt
+        more report_profile.tsv
 
     - name: Archive Robot report tests
       if: always()

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -28,4 +28,4 @@ jobs:
       run: |
         cd edamverify/robot/
         export PATH=:/home/runner/work/edamontology/edamontology/edamverify/robot:$PATH
-        robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile edamverify/robot/report_queries.txt
+        robot report --input ../../EDAM_dev.owl --output report_profile.tsv --profile report_queries.txt

--- a/.github/workflows/robot_reason_report.yml
+++ b/.github/workflows/robot_reason_report.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Print report output
       if: always()
       run: |
-        more edamverify/report_profile.tsv
+        more edamverify/robot/report_profile.tsv
 
 
     - name: Archive Robot report tests


### PR DESCRIPTION
TODO:

- [x] Print the TSV results into the stdout, so that it's visible immediately if failing. Fixed: shown in the "Print report output" step after the failing "run report"
- [ ] Would it be possible to print the results directly in the failing job, instead of the following step? (would be easier to find for newcomers)
- [x] Boolean datatype - ~needs further discussion with @albangaignard,~ see https://github.com/edamontology/edamontology/pull/792#issuecomment-992945673. Fixed in #798.
- [ ] Optional/advanced: After a push to a previously open PR, the same workflow runs twice: on push and on pull request. Could that be somehow changed so that it runs only once? (But we still need both the push & PR triggers) -- AFTER @LucieLamothe TRIED VARIOUS TRICKS, IT STILL LOOKS LIKE A MAJOR CHALLENGE
- [x] Merge #783.
- [ ] Merge #771. (Status: @matuskalas to refine, again and ultimately😊)
- [ ] Please do not add EDAM_dev.owl updates here! For the final test when ready for review, either test in a fork, or rebase (or possibly merge main here, but only if everything under control.
- [ ] When approved, please **squash**, not merge (too many commits because of the necessary trial & error)