### PR TITLE
Deleted HumanReadableID property

### DIFF
--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -139,15 +139,6 @@
     
 
 
-    <!-- http://edamontology.org/hasHumanReadableId -->
-
-    <owl:AnnotationProperty rdf:about="http://edamontology.org/hasHumanReadableId">
-        <rdfs:label>hasHumanReadableId</rdfs:label>
-        <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasAlternativeId"/>
-    </owl:AnnotationProperty>
-    
-
-
     <!-- http://edamontology.org/information_standard -->
 
     <owl:AnnotationProperty rdf:about="http://edamontology.org/information_standard">


### PR DESCRIPTION
The property edamontology:hasHumanReadableId is not used, instead a non-existing oboInOwl:hasHumanReadableId is used.