### PR TITLE
Fixed stashing behavior in the pre-commit script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Set the following file types, so that line endings are NEVER changed. The "binary" option does it.
 # N.B. that git hooks do not work in GitHub Desktop (on Win), as a paradox, if they are with the CRLF endings.
-pre-commit binary
+# pre-commit binary
 # N.B. that here we need it also for tabular files, not only truly binary files! There in the current versions, we have CRLF as EOL and possbily LF inside single cells (in CSV).
 *.csv binary
 *.tsv binary

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,7 +5,9 @@ echo INFO: Pre-commit hook running from $PWD
 git version
 
 # Stash any changes to the working tree that are not going to be committed
-git stash -q --keep-index
+# Solution found on website : https://www.darrenlester.com/blog/git-pre-commit-stash
+STASH_NAME=pre-commit-$(date +%s)
+git stash save -q --keep-index $STASH_NAME
 
 #count number of occurrences of owl:Class in the source file
 num_owl_class=$(grep -c 'owl:Class' EDAM_dev.owl)
@@ -21,7 +23,14 @@ else
   echo ERROR: no owl:Class found.
 fi
 
-# Unstash changes to the working tree that we had stashed
-git stash pop -q
+# Retrieve the stash entry number associated with the stash name.
+STASH_NUM=$(git stash list | grep $STASH_NAME | sed -re 's/stash@\{(.*)\}.*/\1/')
 
+#If the number exists then pop that stash entry.
+if [ -n "$STASH_NUM" ]
+    then
+    git stash pop -q stash@{$STASH_NUM}
+fi
+
+# Exit with status code depending on tests 
 exit $owl_class_found


### PR DESCRIPTION
Applies solution from website: https://www.darrenlester.com/blog/git-pre-commit-stash

.gitattributes file modified: "pre-commit binary" line commented out
This line was a hack because of GitHub Desktop on Windows

FIXES #696