### PR TITLE
Added missing dot at end of definition 

### DIFF
--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -96,7 +96,7 @@
 
     <owl:AnnotationProperty rdf:about="http://edamontology.org/deprecation_comment">
         <oboOther:is_metadata_tag rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboOther:is_metadata_tag>
-        <oboInOwl:hasDefinition>A comment explaining why the comment should be or was deprecated, including name of person commenting (jison, mkalas etc.)</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>A comment explaining why the comment should be or was deprecated, including name of person commenting (jison, mkalas etc.).</oboInOwl:hasDefinition>
         <oboInOwl:inSubset>concept_properties</oboInOwl:inSubset>
         <rdfs:label>deprecation_comment</rdfs:label>
     </owl:AnnotationProperty>
@@ -276,7 +276,7 @@
 
     <owl:AnnotationProperty rdf:about="http://edamontology.org/refactor_comment">
         <oboOther:is_metadata_tag rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</oboOther:is_metadata_tag>
-        <oboInOwl:hasDefinition>A comment explaining the proposed refactoring, including name of person commenting (jison, mkalas etc.)</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>A comment explaining the proposed refactoring, including name of person commenting (jison, mkalas etc.).</oboInOwl:hasDefinition>
         <oboInOwl:inSubset>concept_properties</oboInOwl:inSubset>
         <rdfs:label>refactor_comment</rdfs:label>
     </owl:AnnotationProperty>
@@ -2701,7 +2701,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <created_in>beta12orEarlier</created_in>
-        <oboInOwl:hasDefinition>Two-dimensional gel electrophoresis image</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Two-dimensional gel electrophoresis image.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#data"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <rdfs:label>2D PAGE image</rdfs:label>
@@ -13586,7 +13586,7 @@
         <created_in>beta12orEarlier</created_in>
         <regex>AT[1-5]G[0-9]{5}</regex>
         <oboInOwl:hasDbXref>http://www.geneontology.org/doc/GO.xrf_abbs:AGI_LocusCode</oboInOwl:hasDbXref>
-        <oboInOwl:hasDefinition>Locus identifier for Arabidopsis Genome Initiative (TAIR, TIGR and MIPS databases)</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Locus identifier for Arabidopsis Genome Initiative (TAIR, TIGR and MIPS databases).</oboInOwl:hasDefinition>
         <oboInOwl:hasExactSynonym>AGI ID</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>AGI identifier</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>AGI locus code</oboInOwl:hasExactSynonym>
@@ -32646,7 +32646,7 @@
         </rdfs:subClassOf>
         <created_in>1.3</created_in>
         <documentation rdf:resource="http://samtools.sourceforge.net/SAMv1.pdf"/>
-        <oboInOwl:hasDefinition>BAM indexing format</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>BAM indexing format.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:label>BAI</rdfs:label>
@@ -32660,7 +32660,7 @@
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_1370"/>
         <created_in>1.3</created_in>
         <documentation rdf:resource="ftp://selab.janelia.org/pub/software/hmmer/2.4i/Userguide.pdf"/>
-        <oboInOwl:hasDefinition>HMMER profile HMM file for HMMER versions 2.x</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>HMMER profile HMM file for HMMER versions 2.x.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:label>HMMER2</rdfs:label>
@@ -32674,7 +32674,7 @@
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_1370"/>
         <created_in>1.3</created_in>
         <documentation rdf:resource="ftp://selab.janelia.org/pub/software/hmmer/CURRENT/Userguide.pdf"/>
-        <oboInOwl:hasDefinition>HMMER profile HMM file for HMMER versions 3.x</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>HMMER profile HMM file for HMMER versions 3.x.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:label>HMMER3</rdfs:label>
@@ -32702,7 +32702,7 @@
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_1333"/>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2332"/>
         <created_in>1.3</created_in>
-        <oboInOwl:hasDefinition>XML format as produced by the NCBI Blast package</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>XML format as produced by the NCBI Blast package.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:label>BLAST XML results format</rdfs:label>
@@ -32718,7 +32718,7 @@
         <created_in>1.7</created_in>
         <documentation>http://www.ebi.ac.uk/ena/software/cram-usage#format_specification http://samtools.github.io/hts-specs/CRAMv2.1.pdf</documentation>
         <oboInOwl:hasDbXref>http://www.ebi.ac.uk/ena/software/cram-usage#format_specification http://samtools.github.io/hts-specs/CRAMv2.1.pdf</oboInOwl:hasDbXref>
-        <oboInOwl:hasDefinition>Reference-based compression of alignment format</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Reference-based compression of alignment format.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:label>CRAM</rdfs:label>
@@ -32751,7 +32751,7 @@
     <owl:Class rdf:about="http://edamontology.org/format_3466">
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_3696"/>
         <created_in>1.7</created_in>
-        <oboInOwl:hasDefinition>Encapsulated PostScript format</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Encapsulated PostScript format.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:label>EPS</rdfs:label>
@@ -32979,7 +32979,7 @@
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2333"/>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_3507"/>
         <created_in>1.8</created_in>
-        <oboInOwl:hasDefinition>Portable Document Format</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Portable Document Format.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:label>PDF</rdfs:label>
@@ -33207,7 +33207,7 @@
         <created_in>1.11</created_in>
         <documentation rdf:resource="http://seqanswers.com/wiki/AFG"/>
         <oboInOwl:hasDbXref rdf:resource="http://seqanswers.com/wiki/AFG"/>
-        <oboInOwl:hasDefinition>AFG is a single text-based file assembly format that holds read and consensus information together</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>AFG is a single text-based file assembly format that holds read and consensus information together.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:label>afg</rdfs:label>
@@ -33223,7 +33223,7 @@
         <created_in>1.11</created_in>
         <documentation rdf:resource="http://genome.ucsc.edu/FAQ/FAQformat#format1.8"/>
         <oboInOwl:hasDbXref rdf:resource="http://genome.ucsc.edu/FAQ/FAQformat#format1.8"/>
-        <oboInOwl:hasDefinition>The bedGraph format allows display of continuous-valued data in track format. This display type is useful for probability scores and transcriptome data</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>The bedGraph format allows display of continuous-valued data in track format. This display type is useful for probability scores and transcriptome data.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:comment>Holds a tab-delimited chromosome /start /end / datavalue dataset.</rdfs:comment>
@@ -33581,7 +33581,7 @@
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_3547"/>
         <created_in>1.11</created_in>
         <documentation rdf:resource="https://en.wikipedia.org/wiki/Sun_Raster"/>
-        <oboInOwl:hasDefinition>Sun Raster is a raster graphics file format used on SunOS by Sun Microsystems</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Sun Raster is a raster graphics file format used on SunOS by Sun Microsystems.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
         <rdfs:comment>The SVG specification is an open standard developed by the World Wide Web Consortium (W3C) since 1999.</rdfs:comment>
@@ -34257,7 +34257,7 @@
     <owl:Class rdf:about="http://edamontology.org/format_3696">
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2330"/>
         <created_in>1.13</created_in>
-        <oboInOwl:hasDefinition>PostScript format</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>PostScript format.</oboInOwl:hasDefinition>
         <oboInOwl:hasExactSynonym>PostScript</oboInOwl:hasExactSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
@@ -35364,7 +35364,7 @@
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_3507"/>
         <created_in>1.20</created_in>
         <documentation rdf:resource="https://www.latex-project.org/help/documentation/"/>
-        <oboInOwl:hasDefinition>format for the LaTeX document preparation system</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>format for the LaTeX document preparation system.</oboInOwl:hasDefinition>
         <oboInOwl:hasExactSynonym>LaTeX format</oboInOwl:hasExactSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
@@ -35593,7 +35593,7 @@
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_1921"/>
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_2333"/>
         <created_in>1.20</created_in>
-        <oboInOwl:hasDefinition>Binary format used by the ARB software suite</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Binary format used by the ARB software suite.</oboInOwl:hasDefinition>
         <oboInOwl:hasExactSynonym>ARB binary format</oboInOwl:hasExactSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#formats"/>
@@ -36319,7 +36319,7 @@
         <rdfs:subClassOf rdf:resource="http://edamontology.org/format_3868"/>
         <created_in>1.22</created_in>
         <documentation rdf:resource="http://ambermd.org/formats.html#restart"/>
-        <oboInOwl:hasDefinition>AMBER coordinate/restart file with 6 coordinates per line and decimal format F12.7 (fixed point notation with field width 12 and 7 decimal places)</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>AMBER coordinate/restart file with 6 coordinates per line and decimal format F12.7 (fixed point notation with field width 12 and 7 decimal places).</oboInOwl:hasDefinition>
         <oboInOwl:hasExactSynonym>restrt</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>rst7</oboInOwl:hasExactSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
@@ -47649,7 +47649,7 @@
         <oldParent rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <oboInOwl:consider rdf:resource="http://edamontology.org/operation_0306"/>
         <oboInOwl:consider rdf:resource="http://edamontology.org/operation_3778"/>
-        <oboInOwl:hasDefinition>Analyse a body of scientific text (typically a full text article from a scientific journal.)</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Analyse a body of scientific text (typically a full text article from a scientific journal).</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#obsolete"/>
         <rdfs:label>Article analysis</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -49331,7 +49331,7 @@
     <owl:Class rdf:about="http://edamontology.org/operation_3359">
         <rdfs:subClassOf rdf:resource="http://edamontology.org/operation_2409"/>
         <created_in>1.4</created_in>
-        <oboInOwl:hasDefinition>Split a file containing multiple data items into many files, each containing one item</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Split a file containing multiple data items into many files, each containing one item.</oboInOwl:hasDefinition>
         <oboInOwl:hasExactSynonym>File splitting</oboInOwl:hasExactSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#operations"/>
@@ -50473,10 +50473,10 @@
     <owl:Class rdf:about="http://edamontology.org/operation_3642">
         <rdfs:subClassOf rdf:resource="http://edamontology.org/operation_3635"/>
         <created_in>1.12</created_in>
-        <oboInOwl:hasDefinition>Quantification analysis using chemical labeling by stable isotope dimethylation</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Quantification analysis using chemical labeling by stable isotope dimethylation.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#operations"/>
-        <rdfs:label>Dimethyl</rdfs:label>
+        <rdfs:label>Stable isotope dimethyl labelling</rdfs:label>
     </owl:Class>
     
 
@@ -51359,7 +51359,7 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <created_in>1.22</created_in>
-        <oboInOwl:hasDefinition>Obtain force field parameters (charge, bonds, dihedrals, etc.) from a molecule, to be used in molecular simulations</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Obtain force field parameters (charge, bonds, dihedrals, etc.) from a molecule, to be used in molecular simulations.</oboInOwl:hasDefinition>
         <oboInOwl:hasExactSynonym>Ligand parameterization</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Molecule parameterization</oboInOwl:hasExactSynonym>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#edam"/>
@@ -54601,7 +54601,7 @@
         <created_in>beta12orEarlier</created_in>
         <obsolete_since>1.13</obsolete_since>
         <oldParent rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
-        <oboInOwl:hasDefinition>Protein-coding regions including coding sequences (CDS), exons, translation initiation sites and open reading frames</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Protein-coding regions including coding sequences (CDS), exons, translation initiation sites and open reading frames.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#obsolete"/>
         <oboInOwl:replacedBy rdf:resource="http://edamontology.org/topic_3512"/>
         <rdfs:label>Coding RNA</rdfs:label>
@@ -54949,7 +54949,7 @@
         <obsolete_since>1.3</obsolete_since>
         <oldParent rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <oboInOwl:consider rdf:resource="http://edamontology.org/topic_0121"/>
-        <oboInOwl:hasDefinition>Protein and peptide identification</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Protein and peptide identification.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#obsolete"/>
         <rdfs:label>Protein and peptide identification</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -55000,7 +55000,7 @@
         <obsolete_since>1.3</obsolete_since>
         <oldParent rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <oboInOwl:consider rdf:resource="http://edamontology.org/topic_3307"/>
-        <oboInOwl:hasDefinition>Theoretical biology</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Theoretical biology.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#obsolete"/>
         <rdfs:label>Theoretical biology</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -56422,7 +56422,7 @@
         <obsolete_since>1.3</obsolete_since>
         <oldParent rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
         <oboInOwl:consider rdf:resource="http://edamontology.org/topic_0128"/>
-        <oboInOwl:hasDefinition>Protein interaction networks</oboInOwl:hasDefinition>
+        <oboInOwl:hasDefinition>Protein interaction networks.</oboInOwl:hasDefinition>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/edam#obsolete"/>
         <rdfs:label>Protein interaction networks</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>


### PR DESCRIPTION
\+ modif of topic_3642 label
The label didn't make much sense as just "Dimethyl" I changed it to "Stable isotope dimethyl labelling"

:exclamation:  Once merged, the formating test in caseologue can be moved from curation to essential is wanted  :exclamation: 