### PR TITLE
Add QC and MS QC operations

### DIFF
--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -14,8 +14,8 @@
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
      xmlns:oboLegacy="http://purl.obolibrary.org/obo/">
     <owl:Ontology rdf:about="http://edamontology.org">
-        <next_id>4049</next_id>
-        <oboLegacy:date>12.09.2024 15:35 UTC</oboLegacy:date>
+        <next_id>4050</next_id>
+        <oboLegacy:date>12.09.2024 15:56 UTC</oboLegacy:date>
         <oboLegacy:idspace>EDAM http://edamontology.org/ &quot;EDAM relations, concept properties, and subsets&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_data http://edamontology.org/data_ &quot;EDAM types of data&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_format http://edamontology.org/format_ &quot;EDAM data formats&quot;</oboLegacy:idspace>
@@ -61214,6 +61214,28 @@
         <rdfs:label>Version control</rdfs:label>
         <rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Version_control"/>
         <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q189439"/>
+    </owl:Class>
+    
+
+
+    <!-- http://edamontology.org/topic_4049 -->
+
+    <owl:Class rdf:about="http://edamontology.org/topic_4049">
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/topic_0605"/>
+        <created_in>1.26</created_in>
+        <related_term>Code stewardship</related_term>
+        <related_term>Software stewardship</related_term>
+        <related_term>Software curation</related_term>
+        <oboInOwl:created_by>Matúš Kalaš</oboInOwl:created_by>
+        <oboInOwl:creation_date>2023-02-25T02:40:36.851802Z</oboInOwl:creation_date>
+        <oboInOwl:hasDefinition>Software management comprises the practices and principles of taking care of software, other than programming it. This includes for example taking care of the associated information and documentation, and the processes of contribution, validation, release/publication, or deployment.</oboInOwl:hasDefinition>
+        <oboInOwl:inSubset rdf:resource="http://edamontology.org/bio"/>
+        <oboInOwl:inSubset rdf:resource="http://edamontology.org/topics"/>
+        <oboInOwl:savedBy>bianchini</oboInOwl:savedBy>
+        <oboInOwl:savedBy>Matúš Kalaš</oboInOwl:savedBy>
+        <rdfs:comment>The purpose of software management is keeping software consistent, easy to use, update, and expand. Good software management improves the visibility, impact, and lifetime of software.</rdfs:comment>
+        <rdfs:label>Software management</rdfs:label>
+        <skos:relatedMatch rdf:resource="https://www.wikidata.org/wiki/Q947779"/>
     </owl:Class>
     
 

--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -14,8 +14,8 @@
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
      xmlns:oboLegacy="http://purl.obolibrary.org/obo/">
     <owl:Ontology rdf:about="http://edamontology.org">
-        <next_id>4046</next_id>
-        <oboLegacy:date>11.09.2024 23:08 UTC</oboLegacy:date>
+        <next_id>4049</next_id>
+        <oboLegacy:date>12.09.2024 15:35 UTC</oboLegacy:date>
         <oboLegacy:idspace>EDAM http://edamontology.org/ &quot;EDAM relations, concept properties, and subsets&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_data http://edamontology.org/data_ &quot;EDAM types of data&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_format http://edamontology.org/format_ &quot;EDAM data formats&quot;</oboLegacy:idspace>
@@ -61193,6 +61193,27 @@
         <skos:narrowMatch rdf:resource="https://www.wikidata.org/wiki/Q3510521"/>
         <skos:narrowMatch rdf:resource="https://www.wikidata.org/wiki/Q899388"/>
         <skos:relatedMatch rdf:resource="https://www.wikidata.org/wiki/Q189900"/>
+    </owl:Class>
+    
+
+
+    <!-- http://edamontology.org/topic_4048 -->
+
+    <owl:Class rdf:about="http://edamontology.org/topic_4048">
+        <rdfs:subClassOf rdf:resource="http://edamontology.org/topic_0605"/>
+        <created_in>1.26</created_in>
+        <oboInOwl:created_by>Matúš Kalaš</oboInOwl:created_by>
+        <oboInOwl:creation_date>2023-02-09T11:13:21.41427Z</oboInOwl:creation_date>
+        <oboInOwl:hasDefinition>Version control is a technology for consistent management, storing, and sharing of evolving versions of digital artefacts, such as computer programs, scripts, documents, data, or media files.</oboInOwl:hasDefinition>
+        <oboInOwl:inSubset rdf:resource="http://edamontology.org/bio"/>
+        <oboInOwl:inSubset rdf:resource="http://edamontology.org/topics"/>
+        <oboInOwl:savedBy>bianchini</oboInOwl:savedBy>
+        <oboInOwl:savedBy>Matúš Kalaš</oboInOwl:savedBy>
+        <rdfs:comment>Distributed version control is particularly useful for open, collaborative development of software and other creative work, enabling global communities to work cohesively.</rdfs:comment>
+        <rdfs:comment>Version control originates from software engineering for managing source code, but it is applicable to other digital artefacts, especially any kind of text-based files. With certain limitations, version control can also be applied to binary files.</rdfs:comment>
+        <rdfs:label>Version control</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://en.wikipedia.org/wiki/Version_control"/>
+        <skos:exactMatch rdf:resource="https://www.wikidata.org/wiki/Q189439"/>
     </owl:Class>
     
 


### PR DESCRIPTION
N.B.: Please don't get confused by this being branched from the software-management branch/PR (that one will be merged sooner). A technicality with the succession of IDs.

@magnuspalmblad says:

> We noticed there is no generic operation "quality control" in EDAM. Is "quality control" considered a synonym of "Evaluation and validation"? If so, this should probably be made explicit. If not, then should "quality control" be a new subclass, between "Evaluation and validation" and "Sequencing quality control" (and a possible future "Mass spectrometry quality control")?
> 
> If I already brought this up, then please see this as a reminder to ourselves to revisit this. I think the fact that at least 20 tools perform mass spectrometry data quality control merit a term in EDAM! 🙂

@matuskalas:

> Absolutely! These should be included. To complicate it a bit: Would you say there is a difference between MS DATA QC and MS QC?