### PR TITLE
Added some OWL ontology annotation properties: versionIRI, versionInfo, priorVersion

### DIFF
--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -15,7 +15,7 @@
      xmlns:oboLegacy="http://purl.obolibrary.org/obo/">
     <owl:Ontology rdf:about="http://edamontology.org">
         <next_id>4046</next_id>
-        <oboLegacy:date>19.09.2024 15:44 UTC</oboLegacy:date>
+        <oboLegacy:date>19.09.2024 22:22 UTC</oboLegacy:date>
         <oboLegacy:idspace>EDAM http://edamontology.org/ &quot;EDAM relations, concept properties, and subsets&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_data http://edamontology.org/data_ &quot;EDAM types of data&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_format http://edamontology.org/format_ &quot;EDAM data formats&quot;</oboLegacy:idspace>
@@ -46,9 +46,9 @@
         <oboInOwl:hasSubset rdf:resource="http://edamontology.org/operations"/>
         <oboInOwl:hasSubset rdf:resource="http://edamontology.org/topics"/>
         <oboInOwl:savedBy>Matúš Kalaš</oboInOwl:savedBy>
-        <owl:priorVersion rdf:resource="http://edamontology.org/EDAM_1.25.owl"/>
-        <owl:versionIRI rdf:resource="http://edamontology.org/EDAM_1.25.owl#TODO-UPDATE-ON-RELEASE"/>
-        <owl:versionInfo>dev(1.26)20240919-1544Z</owl:versionInfo>
+        <owl:priorVersion rdf:resource="http://edamontology.org/EDAM_1.25"/>
+        <owl:versionIRI rdf:resource="http://edamontology.org/EDAM_1.25-20240919T2222Z-dev(1.26)#TODO-UPDATE-ON-RELEASE"/>
+        <owl:versionInfo>1.25-20240919T2222Z-dev(1.26)</owl:versionInfo>
         <rdfs:isDefinedBy rdf:resource="http://edamontology.org/EDAM.owl"/>
         <foaf:page rdf:resource="http://edamontology.org/page"/>
         <foaf:logo rdf:resource="https://raw.githubusercontent.com/edamontology/edamontology/main/EDAM-logo-square.svg"/>

--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -15,7 +15,7 @@
      xmlns:oboLegacy="http://purl.obolibrary.org/obo/">
     <owl:Ontology rdf:about="http://edamontology.org">
         <next_id>4046</next_id>
-        <oboLegacy:date>19.09.2024 14:21 UTC</oboLegacy:date>
+        <oboLegacy:date>19.09.2024 15:44 UTC</oboLegacy:date>
         <oboLegacy:idspace>EDAM http://edamontology.org/ &quot;EDAM relations, concept properties, and subsets&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_data http://edamontology.org/data_ &quot;EDAM types of data&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_format http://edamontology.org/format_ &quot;EDAM data formats&quot;</oboLegacy:idspace>
@@ -46,6 +46,9 @@
         <oboInOwl:hasSubset rdf:resource="http://edamontology.org/operations"/>
         <oboInOwl:hasSubset rdf:resource="http://edamontology.org/topics"/>
         <oboInOwl:savedBy>Matúš Kalaš</oboInOwl:savedBy>
+        <owl:priorVersion rdf:resource="http://edamontology.org/EDAM_1.25.owl"/>
+        <owl:versionIRI rdf:resource="http://edamontology.org/EDAM_1.25.owl#TODO-UPDATE-ON-RELEASE"/>
+        <owl:versionInfo>dev(1.26)20240919-1544Z</owl:versionInfo>
         <rdfs:isDefinedBy rdf:resource="http://edamontology.org/EDAM.owl"/>
         <foaf:page rdf:resource="http://edamontology.org/page"/>
         <foaf:logo rdf:resource="https://raw.githubusercontent.com/edamontology/edamontology/main/EDAM-logo-square.svg"/>

--- a/EDAM_dev.owl
+++ b/EDAM_dev.owl
@@ -15,7 +15,7 @@
      xmlns:oboLegacy="http://purl.obolibrary.org/obo/">
     <owl:Ontology rdf:about="http://edamontology.org">
         <next_id>4046</next_id>
-        <oboLegacy:date>19.09.2024 22:22 UTC</oboLegacy:date>
+        <oboLegacy:date>20.09.2024 12:40 UTC</oboLegacy:date>
         <oboLegacy:idspace>EDAM http://edamontology.org/ &quot;EDAM relations, concept properties, and subsets&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_data http://edamontology.org/data_ &quot;EDAM types of data&quot;</oboLegacy:idspace>
         <oboLegacy:idspace>EDAM_format http://edamontology.org/format_ &quot;EDAM data formats&quot;</oboLegacy:idspace>
@@ -34,7 +34,7 @@
         <has_format rdf:resource="http://edamontology.org/format_2197"/>
         <dc:title>EDAM - The ontology of data analysis and management</dc:title>
         <dc:description>EDAM is a domain ontology of data analysis and data management in bio- and other sciences, and science-based applications. It comprises concepts related to analysis, modelling, optimisation, and data life-cycle. Targetting usability by diverse users, the structure of EDAM is relatively simple, divided into 4 main sections: Topic, Operation, Data (incl. Identifier), and Format.</dc:description>
-        <doap:Version>1.26_dev</doap:Version>
+        <doap:Version>dev(1.26)</doap:Version>
         <dcterms:license rdf:resource="https://creativecommons.org/licenses/by-sa/4.0"/>
         <oboInOwl:hasSubset rdf:resource="http://edamontology.org/properties"/>
         <oboInOwl:hasSubset rdf:resource="http://edamontology.org/data"/>
@@ -47,8 +47,8 @@
         <oboInOwl:hasSubset rdf:resource="http://edamontology.org/topics"/>
         <oboInOwl:savedBy>Matúš Kalaš</oboInOwl:savedBy>
         <owl:priorVersion rdf:resource="http://edamontology.org/EDAM_1.25"/>
-        <owl:versionIRI rdf:resource="http://edamontology.org/EDAM_1.25-20240919T2222Z-dev(1.26)#TODO-UPDATE-ON-RELEASE"/>
-        <owl:versionInfo>1.25-20240919T2222Z-dev(1.26)</owl:versionInfo>
+        <owl:versionIRI rdf:resource="http://edamontology.org/EDAM_1.25-20240920T1240Z-dev(1.26)#TODO-UPDATE-ON-RELEASE"/>
+        <owl:versionInfo>1.25-20240920T1240Z-dev(1.26)</owl:versionInfo>
         <rdfs:isDefinedBy rdf:resource="http://edamontology.org/EDAM.owl"/>
         <foaf:page rdf:resource="http://edamontology.org/page"/>
         <foaf:logo rdf:resource="https://raw.githubusercontent.com/edamontology/edamontology/main/EDAM-logo-square.svg"/>

--- a/releases/EDAM.owl
+++ b/releases/EDAM.owl
@@ -38,8 +38,12 @@
         <oboInOwl:hasSubset>relations &quot;EDAM relations&quot;</oboInOwl:hasSubset>
         <oboInOwl:hasSubset>topics &quot;EDAM topics&quot;</oboInOwl:hasSubset>
         <oboInOwl:savedBy>Jon Ison, Matúš Kalaš, Hervé Ménager</oboInOwl:savedBy>
+        <owl:versionIRI rdf:resource="http://edamontology.org/EDAM_1.25"/>
+        <owl:versionInfo>1.25-20200618T0915Z</owl:versionInfo>
         <rdfs:isDefinedBy rdf:resource="http://edamontology.org/EDAM.owl"/>
         <foaf:page rdf:resource="http://edamontology.org/page"/>
+        <foaf:logo rdf:resource="https://raw.githubusercontent.com/edamontology/edamontology/main/EDAM-logo-square.svg"/>
+        <repository rdf:resource="https://github.com/edamontology/edamontology"/>
     </owl:Ontology>
     
 

--- a/releases/EDAM_1.25.owl
+++ b/releases/EDAM_1.25.owl
@@ -38,8 +38,12 @@
         <oboInOwl:hasSubset>relations &quot;EDAM relations&quot;</oboInOwl:hasSubset>
         <oboInOwl:hasSubset>topics &quot;EDAM topics&quot;</oboInOwl:hasSubset>
         <oboInOwl:savedBy>Jon Ison, Matúš Kalaš, Hervé Ménager</oboInOwl:savedBy>
+        <owl:versionIRI rdf:resource="http://edamontology.org/EDAM_1.25"/>
+        <owl:versionInfo>1.25-20200618T0915Z</owl:versionInfo>
         <rdfs:isDefinedBy rdf:resource="http://edamontology.org/EDAM.owl"/>
         <foaf:page rdf:resource="http://edamontology.org/page"/>
+        <foaf:logo rdf:resource="https://raw.githubusercontent.com/edamontology/edamontology/main/EDAM-logo-square.svg"/>
+        <repository rdf:resource="https://github.com/edamontology/edamontology"/>
     </owl:Ontology>
     
 


### PR DESCRIPTION
Fixes #870

Note: This will only be useful when updated at the time of the next (unstable) release.

Note: For the unstable releases, the versionIRI will not resolve until we fix that in the web server. See my notes in #870

Note: There are more OWL ontology annotation properties to add, and generally polish the header, see #898